### PR TITLE
feat: Keep the visual position of the tab after clicking

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -7,3 +7,28 @@ export const isCustom = (event: Event) => {
     const target = getEventTarget(event);
     return !target || !(target as HTMLElement).matches;
 };
+
+export const getClosestScrollableParent = (element: HTMLElement): HTMLElement | undefined => {
+    if (Math.abs(element.scrollHeight - element.clientHeight) > 1) {
+        return element;
+    }
+
+    return element.parentElement ? getClosestScrollableParent(element.parentElement) : undefined;
+};
+
+export interface ElementOffset {
+    top: number;
+    left: number;
+}
+
+export const getOffsetByScrollableParent = (
+    element: HTMLElement,
+    scrollableParent: HTMLElement,
+): ElementOffset => {
+    const elementBounds = element.getBoundingClientRect();
+    const scrollableParentBounds = scrollableParent.getBoundingClientRect();
+    return {
+        top: elementBounds.top - scrollableParentBounds.top,
+        left: elementBounds.left - scrollableParentBounds.left,
+    };
+};


### PR DESCRIPTION
If there are several tab lists on the page with one group, the position of the tab clicked could change due to changing scroll of the parent container. The current feature keeps the visual position of the tab after clicking. Example:

https://github.com/diplodoc-platform/tabs-extension/assets/4435642/659463f0-dfd0-4f01-bacb-c7aff2690e90

This feature works with the first found scrollable parent.