### PR TITLE
fix(styles): don't override counter in list when `.yfm_no-list-reset` is set

### DIFF
--- a/src/runtime/scss/tabs.scss
+++ b/src/runtime/scss/tabs.scss
@@ -1,7 +1,7 @@
 .yfm-tabs {
     margin-bottom: 15px;
 
-    ol {
+    .yfm:not(.yfm_no-list-reset) & ol {
         counter-reset: tabs-list;
 
         & > li {


### PR DESCRIPTION
Current situation:
<img width="212" alt="Screenshot 2023-08-30 at 16 46 36" src="https://github.com/diplodoc-platform/tabs-extension/assets/26671342/f07954f2-dedf-4ec6-99ad-8c821247b9ef">
