### PR TITLE
fix: Change hidden tabs rendering mode

### DIFF
--- a/src/runtime/scss/tabs.scss
+++ b/src/runtime/scss/tabs.scss
@@ -48,7 +48,8 @@
 }
 
 .yfm-tab-panel {
-    display: none;
+    visibility: hidden;
+    height: 0;
 
     &:first-child {
         margin-top: 0 !important;
@@ -59,6 +60,7 @@
     }
 
     &.active {
-        display: block;
+        visibility: visible;
+        height: auto;
     }
 }


### PR DESCRIPTION
Render hidden tabs with visibility hidden instead of display none. This allow to properly compute internal dimentions.