### PR TITLE
fix: fixed parsing of tab contents without indentation

### DIFF
--- a/src/plugin/transform.ts
+++ b/src/plugin/transform.ts
@@ -337,14 +337,14 @@ export function transform({
                 const tabsGroup = match[2] || `${DEFAULT_TABS_GROUP_PREFIX}${generateID()}`;
                 const orientation = (match[4] || 'horizontal') as TabsOrientation;
 
-                const {tabs, index} = findTabs(state.tokens, i + 3);
+                const {tabs} = findTabs(state.tokens, i + 3);
 
                 if (tabs.length > 0) {
                     insertTabs(
                         tabs,
                         state,
                         orientation,
-                        {start: i, end: index + 3},
+                        {start: i, end: closeTokenIdx + 2},
                         {
                             containerClasses,
                             tabsGroup,
@@ -354,7 +354,7 @@ export function transform({
                     i++;
                     tabsAreInserted = true;
                 } else {
-                    state.tokens.splice(i, index - i);
+                    state.tokens.splice(i, closeTokenIdx - i + 3);
                 }
             }
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -173,6 +173,79 @@ describe('plugin', () => {
         expect(tokens.map((token) => token.type)).toEqual(nestedTokenTypes);
     });
 
+    it('should return valid token stream if content without indentation', () => {
+        // ACT
+        const {tokens} = makeTransform({
+            content: [
+                '{% list tabs %}',
+                '',
+                '- tab1',
+                '',
+                '> quote',
+                '',
+                '{% endlist %}',
+            ],
+        });
+
+        // ASSERT
+        expect(tokens.map((token) => token.type)).toEqual([
+            'tabs_open',
+            'tab-list_open',
+            'tab_open',
+            'inline',
+            'tab_close',
+            'tab-list_close',
+            'tab-panel_open',
+            'tab-panel_close',
+            'tabs_close',
+        ]);
+    });
+
+    it('should remove empty tabs', () => {
+        // ACT
+        const {tokens} = makeTransform({
+            content: [
+                'before',
+                '',
+                '{% list tabs %}',
+                '',
+                '',
+                '',
+                '{% endlist %}',
+                '',
+                'after',
+            ],
+        });
+
+        // ASSERT
+        expect(tokens.map((token) => token.type)).toEqual([
+            "paragraph_open",
+            "inline",
+            "paragraph_close",
+            "paragraph_open",
+            "inline",
+            "paragraph_close",
+        ]);
+        expect(tokens[1].content).toBe('before');
+        expect(tokens[4].content).toBe('after')
+    });
+
+    it('should remove tabs with invalid markup inside', () => {
+        // ACT
+        const {tokens} = makeTransform({
+            content: [
+                '{% list tabs %}',
+                '',
+                '> 123',
+                '',
+                '{% endlist %}',
+            ],
+        });
+
+        // ASSERT
+        expect(tokens.map((token) => token.type)).toEqual([]);
+    });
+
     describe('options', () => {
         test('should add an extra className to container node', () => {
             // ACT


### PR DESCRIPTION
If the contents of tab don't contain indentation, the tabs-extension creates an invalid token stream. Example:
```
{% list tabs %}

- tab1

> quote

{% endlist %}
```
Tokens:
```
tabs_open,
tab-list_open,
tab_open,
inline,
tab_close,
tab-list_close,
tab-panel_open,
tab-panel_close,
tabs_close,
paragraph_close,
blockquote_close,
paragraph_open,
inline,
paragraph_close,
```

I fixed that case. Now this markup creates valid tokens:
```
"tabs_open",
"tab-list_open",
"tab_open",
"inline",
"tab_close",
"tab-list_close",
"tab-panel_open",
"tab-panel_close",
"tabs_close",
```