### PR TITLE
Prune redundant list styles

### DIFF
--- a/src/runtime/scss/tabs.scss
+++ b/src/runtime/scss/tabs.scss
@@ -1,17 +1,5 @@
 .yfm-tabs {
     margin-bottom: 15px;
-
-    .yfm:not(.yfm_no-list-reset) & ol {
-        counter-reset: tabs-list;
-
-        & > li {
-            counter-increment: tabs-list;
-
-            &::before {
-                content: counters(tabs-list, '.') '. ';
-            }
-        }
-    }
 }
 
 .yfm-tab-list {


### PR DESCRIPTION
Styles removed were previously made redundant by https://github.com/diplodoc-platform/transform/pull/628.