### PR TITLE
feat: add map attribute to tab-panel tokens

### DIFF
--- a/src/plugin/utils/tabs.ts
+++ b/src/plugin/utils/tabs.ts
@@ -1,3 +1,5 @@
+import type Token from 'markdown-it/lib/token';
+
 import GithubSlugger from 'github-slugger';
 
 import {ACTIVE_TAB_TEXT} from '../../common';
@@ -58,4 +60,18 @@ function getRawId(tab: RuntimeTab): string {
     const {customAnchor, name} = parseName(tab.name);
 
     return customAnchor || name;
+}
+
+export function getContentMap(tokens: Token[]): [number, number] | null {
+    let firstMap: [number, number] | null = null;
+    let lastMap: [number, number] | null = null;
+
+    tokens.forEach(({map}) => {
+        if (map) {
+            firstMap = firstMap ?? map;
+            lastMap = map;
+        }
+    });
+
+    return firstMap && lastMap ? [firstMap[0], lastMap[1]] : null;
 }

--- a/src/plugin/variants/accordion.ts
+++ b/src/plugin/variants/accordion.ts
@@ -15,7 +15,7 @@ import {
     TAB_PANEL_CLASSNAME,
     TabsVariants,
 } from '../../common';
-import {generateID, getName, getTabId, getTabKey, isTabSelected} from '../utils';
+import {generateID, getContentMap, getName, getTabId, getTabKey, isTabSelected} from '../utils';
 import {type RuntimeTab} from '../types';
 
 import {type TabsTokensGenerator} from './types';
@@ -83,6 +83,7 @@ export const accordion: TabsTokensGenerator = (
 
         tabOpen.map = tabs[i].listItem.map;
         tabOpen.markup = tabs[i].listItem.markup;
+        tabPanelOpen.map = getContentMap(tabs[i].tokens);
         tabText.content = tabs[i].name;
         tabInline.children = [tabText];
         tabOpen.block = true;

--- a/src/plugin/variants/dropdown.ts
+++ b/src/plugin/variants/dropdown.ts
@@ -13,7 +13,7 @@ import {
     TAB_DATA_VARIANT,
     TAB_PANEL_CLASSNAME,
 } from '../../common';
-import {generateID, getName, getTabId, getTabKey, isTabSelected} from '../utils';
+import {generateID, getContentMap, getName, getTabId, getTabKey, isTabSelected} from '../utils';
 import {type RuntimeTab} from '../types';
 
 import {type TabsTokensGenerator} from './types';
@@ -124,6 +124,7 @@ export const dropdown: TabsTokensGenerator = (
 
         const tabPanelId = generateID();
 
+        tabPanelOpen.map = getContentMap(tabs[i].tokens);
         tabPanelOpen.block = true;
         tabPanelClose.block = true;
         tabPanelOpen.attrSet('id', tabPanelId);

--- a/src/plugin/variants/radio.ts
+++ b/src/plugin/variants/radio.ts
@@ -16,7 +16,7 @@ import {
     TAB_PANEL_CLASSNAME,
     VERTICAL_TAB_CLASSNAME,
 } from '../../common';
-import {generateID, getName, getTabId, getTabKey, isTabSelected} from '../utils';
+import {generateID, getContentMap, getName, getTabId, getTabKey, isTabSelected} from '../utils';
 import {type RuntimeTab} from '../types';
 
 import {type TabsTokensGenerator} from './types';
@@ -93,6 +93,7 @@ export const radio: TabsTokensGenerator = (
 
         tabOpen.map = tabs[i].listItem.map;
         tabOpen.markup = tabs[i].listItem.markup;
+        tabPanelOpen.map = getContentMap(tabs[i].tokens);
         tabText.content = tabs[i].name;
         tabInline.children = [tabText];
         tabOpen.block = true;

--- a/src/plugin/variants/regular.ts
+++ b/src/plugin/variants/regular.ts
@@ -13,7 +13,7 @@ import {
     TAB_PANEL_CLASSNAME,
     VERTICAL_TAB_CLASSNAME,
 } from '../../common';
-import {generateID, getName, getTabId, getTabKey, isTabSelected} from '../utils';
+import {generateID, getContentMap, getName, getTabId, getTabKey, isTabSelected} from '../utils';
 
 import {TabsTokensGenerator} from './types';
 
@@ -103,6 +103,7 @@ export const regular: TabsTokensGenerator = (
 
         tabOpen.map = tabs[i].listItem.map;
         tabOpen.markup = tabs[i].listItem.markup;
+        tabPanelOpen.map = getContentMap(tabs[i].tokens);
         tabText.content = tabs[i].name;
         tabInline.children = [tabText];
         tabOpen.block = true;

--- a/tests/src/__snapshots__/plugin.test.ts.snap
+++ b/tests/src/__snapshots__/plugin.test.ts.snap
@@ -1,5 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`plugin TabPanel structure for accordion tabs 1`] = `
+[
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      4,
+      5,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      8,
+      9,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+]
+`;
+
+exports[`plugin TabPanel structure for dropdown tabs 1`] = `
+[
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      4,
+      5,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      8,
+      9,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+]
+`;
+
+exports[`plugin TabPanel structure for radio tabs 1`] = `
+[
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      6,
+      7,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      9,
+      11,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      13,
+      15,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+]
+`;
+
+exports[`plugin TabPanel structure for regular tabs 1`] = `
+[
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      6,
+      7,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      9,
+      11,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+  {
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      13,
+      15,
+    ],
+    "markup": "",
+    "nesting": 1,
+    "tag": "div",
+    "type": "tab-panel_open",
+  },
+]
+`;
+
 exports[`plugin html snapshots should render common tabs 1`] = `
 <div class="yfm-tabs"
      data-diplodoc-group="defaultTabsGroup-4fzzzxjy"
@@ -353,7 +533,10 @@ exports[`plugin should handle multiple tabs with indented endlist 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      4,
+      5,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -445,7 +628,10 @@ exports[`plugin should handle multiple tabs with indented endlist 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      8,
+      10,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -694,7 +880,10 @@ exports[`plugin should handle multiple tabs with indented endlist 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      13,
+      14,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -1948,7 +2137,10 @@ exports[`plugin should handle tabs inside a last list item 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      8,
+      9,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -2040,7 +2232,10 @@ exports[`plugin should handle tabs inside a last list item 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      12,
+      13,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -2444,7 +2639,10 @@ exports[`plugin should handle tabs inside a list item 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      6,
+      7,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -2536,7 +2734,10 @@ exports[`plugin should handle tabs inside a list item 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      10,
+      11,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -2974,7 +3175,10 @@ exports[`plugin should handle tabs inside ordered list with indented endlist 1`]
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      6,
+      7,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,
@@ -3219,7 +3423,10 @@ exports[`plugin should handle tabs with list inside and indented endlist 1`] = `
     "hidden": false,
     "info": "",
     "level": 0,
-    "map": null,
+    "map": [
+      4,
+      6,
+    ],
     "markup": "",
     "meta": null,
     "nesting": 1,

--- a/tests/src/data/tabs.ts
+++ b/tests/src/data/tabs.ts
@@ -537,7 +537,7 @@ export const base = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [6, 7],
         nesting: 1,
         level: 0,
         children: null,
@@ -623,7 +623,7 @@ export const base = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [9, 11],
         nesting: 1,
         level: 0,
         children: null,
@@ -851,7 +851,7 @@ export const base = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [13, 15],
         nesting: 1,
         level: 0,
         children: null,
@@ -1326,7 +1326,7 @@ export const vertical = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [6, 7],
         nesting: 1,
         level: 0,
         children: null,
@@ -1512,7 +1512,7 @@ export const vertical = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [9, 11],
         nesting: 1,
         level: 0,
         children: null,
@@ -1840,7 +1840,7 @@ export const vertical = [
     {
         type: 'tab-panel_open',
         tag: 'div',
-        map: null,
+        map: [13, 15],
         nesting: 1,
         level: 0,
         children: null,

--- a/tests/src/plugin.test.ts
+++ b/tests/src/plugin.test.ts
@@ -156,6 +156,84 @@ describe('plugin', () => {
         });
     });
 
+    test('TabPanel structure for regular tabs', () => {
+        // ACT
+        const {tokens} = makeTransform();
+
+        // ASSERT
+        const tabPanels = tokens.filter(({type}) => type === 'tab-panel_open');
+        const panelsWithoutAttrs = tabPanels.map(({attrs: _, meta: __, ...rest}) => rest);
+        expect(panelsWithoutAttrs).toMatchSnapshot();
+    });
+
+    test('TabPanel structure for radio tabs', () => {
+        // ACT
+        const {tokens} = makeTransform({content: defaultVerticalContent});
+
+        // ASSERT
+        const tabPanels = tokens.filter(({type}) => type === 'tab-panel_open');
+        const panelsWithoutAttrs = tabPanels.map(({attrs: _, meta: __, ...rest}) => rest);
+        expect(panelsWithoutAttrs).toMatchSnapshot();
+    });
+
+    test('TabPanel structure for accordion tabs', () => {
+        // ACT
+        const content = [
+            '{% list tabs accordion %}',
+            '',
+            '- Tab 1',
+            '',
+            '  Content 1',
+            '',
+            '- Tab 2',
+            '',
+            '  Content 2',
+            '',
+            '{% endlist %}',
+        ];
+
+        const {tokens} = makeTransform({
+            content,
+            transformOptions: {
+                features: {enabledVariants: {accordion: true}},
+            },
+        });
+
+        // ASSERT
+        const tabPanels = tokens.filter(({type}) => type === 'tab-panel_open');
+        const panelsWithoutAttrs = tabPanels.map(({attrs: _, meta: __, ...rest}) => rest);
+        expect(panelsWithoutAttrs).toMatchSnapshot();
+    });
+
+    test('TabPanel structure for dropdown tabs', () => {
+        // ACT
+        const content = [
+            '{% list tabs dropdown %}',
+            '',
+            '- Tab 1',
+            '',
+            '  Content 1',
+            '',
+            '- Tab 2',
+            '',
+            '  Content 2',
+            '',
+            '{% endlist %}',
+        ];
+
+        const {tokens} = makeTransform({
+            content,
+            transformOptions: {
+                features: {enabledVariants: {dropdown: true}},
+            },
+        });
+
+        // ASSERT
+        const tabPanels = tokens.filter(({type}) => type === 'tab-panel_open');
+        const panelsWithoutAttrs = tabPanels.map(({attrs: _, meta: __, ...rest}) => rest);
+        expect(panelsWithoutAttrs).toMatchSnapshot();
+    });
+
     test('Tab syntax is escaped', () => {
         // ACT
         const {tokens: result} = makeTransform({


### PR DESCRIPTION
Adds map attribute to `tab-panel_open` tokens for all tab variants (`regular`, `radio`, `accordion`, `dropdown`). This enables line-based tab activation in other plugins.